### PR TITLE
fix compiler errors with rust 1.5 windows MSVC

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,5 +7,5 @@ authors = ["Marko Mijalkovic <marko.mijalkovic97@gmail.com>"]
 log = "*"
 num = "*"
 libc = "*"
-dylib = "*" # For hosts
+dylib = { git="https://github.com/Earlz/rust-dylib" } # For hosts
 bitflags = "*"

--- a/src/host.rs
+++ b/src/host.rs
@@ -246,8 +246,8 @@ impl PluginInstance {
             let flags = Plugin::from_bits_truncate(effect.flags);
 
             plug.info = Info {
-                name: plug.read_string(op::GetProductName, MAX_PRODUCT_STR_LEN),
-                vendor: plug.read_string(op::GetVendorName, MAX_VENDOR_STR_LEN),
+                name: plug.read_string(op::GetProductName, MAX_PRODUCT_STR_LEN as u64),
+                vendor: plug.read_string(op::GetVendorName, MAX_VENDOR_STR_LEN as u64),
 
                 presets: effect.numPrograms,
                 parameters: effect.numParams,


### PR DESCRIPTION
This hasn't been thoroughly tested, but this actually makes this project work on Windows with Rust 1.5. It currently uses my own fork of dylib with these issues changed, though if the dylib developer merges in my pull request, then I'll of course change it back to the regular dylib.

Also fixes compiler errors in the new host implementation with Rust 1.5
