### PR TITLE
Pin bitflags to older version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,4 +8,4 @@ log = "*"
 num = "*"
 libc = "*"
 dylib = { git="https://github.com/Earlz/rust-dylib" } # For hosts
-bitflags = "*"
+bitflags = "0.4.0"


### PR DESCRIPTION
Bitflags 0.5.0 makes types and constants private by default, which breaks rust-vst2. Before this project is updated to work with the new version, this'll at least keep it building.
