### PR TITLE
Fixed plugin crashes on Windows by changing the calling convention to cdecl

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,4 +8,4 @@ log = "*"
 num = "*"
 libc = "*"
 dylib = { git="https://github.com/Earlz/rust-dylib" } # For hosts
-bitflags = "0.4.0"
+bitflags = "*"

--- a/src/api.rs
+++ b/src/api.rs
@@ -565,7 +565,7 @@ pub struct SysExEvent {
 pub mod flags {
     bitflags! {
         /// Flags for VST channels.
-        flags Channel: i32 {
+        pub flags Channel: i32 {
             /// Indicates channel is active. Ignored by host.
             const ACTIVE = 1,
             /// Indicates channel is first of stereo pair.
@@ -577,7 +577,7 @@ pub mod flags {
 
     bitflags! {
         /// Flags for VST plugins.
-        flags Plugin: i32 {
+        pub flags Plugin: i32 {
             /// Plugin has an editor.
             const HAS_EDITOR = 1 << 0,
             /// Plugin can process 32 bit audio. (Mandatory in VST 2.4).
@@ -595,7 +595,7 @@ pub mod flags {
 
     bitflags!{
         /// Cross platform modifier key flags.
-        flags ModifierKey: u8 {
+        pub flags ModifierKey: u8 {
             /// Shift key.
             const SHIFT = 1 << 0,
             /// Alt key.
@@ -609,7 +609,7 @@ pub mod flags {
 
     bitflags! {
         /// MIDI event flags.
-        flags MidiEvent: i32 {
+        pub flags MidiEvent: i32 {
             /// This event is played live (not in playback from a sequencer track). This allows the
             /// plugin to handle these flagged events with higher priority, especially when the
             /// plugin has a big latency as per `plugin::Info::initial_delay`.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -158,7 +158,7 @@ macro_rules! plugin_main {
 
         #[allow(non_snake_case)]
         #[no_mangle]
-        pub extern "system" fn VSTPluginMain(callback: $crate::api::HostCallbackProc) -> *mut $crate::api::AEffect {
+        pub extern "C" fn VSTPluginMain(callback: $crate::api::HostCallbackProc) -> *mut $crate::api::AEffect {
             $crate::main::<$t>(callback)
         }
     }


### PR DESCRIPTION
I finally tracked down what was causing the stack corruption when loading a Rust VST in a C++ host on Windows. When I debugged it in Visual Studio I got:
`Run-Time Check Failure #0 - The value of ESP was not properly saved across a function call.  This is usually a result of calling a function declared with one calling convention with a function pointer declared with a different calling convention.`
So I found out that the VST SDK specifies cdecl as the calling convention to use..
And when I changed it, it finally worked..

Btw, I debugged it by compiling building this in debug mode:
https://github.com/teragonaudio/MrsWatson
And then it crashed on this line:
https://github.com/teragonaudio/MrsWatson/blob/master/source/plugin/PluginVst2xWindows.cpp#L105

(Btw, I made the bit flags public to be compatible with bitflags 0.5.0)
