### PR TITLE
fixed HostCallback.get_info(), increased MAX_PARAM_STR_LEN to 64

### DIFF
--- a/src/api.rs
+++ b/src/api.rs
@@ -12,7 +12,7 @@ pub mod consts {
     use libc::size_t;
 
     pub const MAX_PRESET_NAME_LEN: size_t = 24;
-    pub const MAX_PARAM_STR_LEN: size_t = 64;
+    pub const MAX_PARAM_STR_LEN: size_t = 32;
     pub const MAX_LABEL: usize = 64;
     pub const MAX_SHORT_LABEL: usize = 8;
     pub const MAX_PRODUCT_STR_LEN: size_t = 64;

--- a/src/api.rs
+++ b/src/api.rs
@@ -12,7 +12,7 @@ pub mod consts {
     use libc::size_t;
 
     pub const MAX_PRESET_NAME_LEN: size_t = 24;
-    pub const MAX_PARAM_STR_LEN: size_t = 8;
+    pub const MAX_PARAM_STR_LEN: size_t = 64;
     pub const MAX_LABEL: usize = 64;
     pub const MAX_SHORT_LABEL: usize = 8;
     pub const MAX_PRODUCT_STR_LEN: size_t = 64;

--- a/src/editor.rs
+++ b/src/editor.rs
@@ -40,6 +40,7 @@ pub trait Editor {
 
 /// Rectangle used to specify dimensions of editor window.
 #[doc(hidden)]
+#[derive(Copy, Clone, Debug)]
 pub struct Rect {
     /// Y value in pixels of top side.
     pub top: i16,
@@ -52,6 +53,7 @@ pub struct Rect {
 }
 
 /// A platform independent key code. Includes modifier keys.
+#[derive(Copy, Clone, Debug)]
 pub struct KeyCode {
     /// ASCII character for key pressed (if applicable).
     pub character: char,


### PR DESCRIPTION
While using rust-vst2 I noticed that a lot of my VST's parameter names were displayed truncated in the VST host because MAX_PARAM_STR_LEN was only 8.
I increased it to 64 (MAX_LABEL, MAX_PRODUCT_STR_LEN and MAX_VENDOR_STR_LEN are also 64).
Also I noticed that HostCallback.get_info() returned the default Host.get_info(), instead of calling into the actual VST host to get its info, so I fixed that.
