### PR TITLE
Added process_events() to Host for sending MIDI output to Host

### DIFF
--- a/src/api.rs
+++ b/src/api.rs
@@ -393,8 +393,8 @@ pub struct Events {
     /// Reserved for future use. Should be 0.
     pub _reserved: isize,
 
-    /// Array of pointers to `api::Event` objects.
-    pub events: *mut Event,
+    /// Variable-length array of pointers to `api::Event` objects.
+    pub events: [*mut Event; 2],
 }
 
 /// The type of event that has occured. See `api::Event.event_type`.

--- a/src/api.rs
+++ b/src/api.rs
@@ -394,7 +394,7 @@ pub struct Events {
     pub _reserved: isize,
 
     /// Array of pointers to `api::Event` objects.
-    pub events: *mut *mut Event,
+    pub events: *mut Event,
 }
 
 /// The type of event that has occured. See `api::Event.event_type`.

--- a/src/api.rs
+++ b/src/api.rs
@@ -56,7 +56,7 @@ pub struct AEffect {
     /// Host to plug-in dispatcher.
     pub dispatcher: DispatcherProc,
 
-	/// Accumulating process mode is deprecated in VST 2.4! Use `processReplacing` instead!
+    /// Accumulating process mode is deprecated in VST 2.4! Use `processReplacing` instead!
     pub _process: ProcessProc,
 
     /// Set value of automatable parameter.
@@ -394,6 +394,9 @@ pub struct Events {
     pub _reserved: isize,
 
     /// Variable-length array of pointers to `api::Event` objects.
+    ///
+    /// The VST standard specifies a variable length array of initial size 2. If there are more
+    /// than 2 elements a larger array must be stored in this structure.
     pub events: [*mut Event; 2],
 }
 

--- a/src/host.rs
+++ b/src/host.rs
@@ -5,6 +5,7 @@ use std::sync::{Arc, Mutex};
 use std::error::Error;
 use std::{fmt, mem, ptr, slice};
 use std::ffi::CString;
+use std::cmp::max;
 
 use libloading::Library;
 use libc::c_void;
@@ -593,12 +594,12 @@ impl Plugin for PluginInstance {
 
         let len = events.len();
 
-        let mut send = vec![0u8; 2 * mem::size_of::<i32>() + len * mem::size_of::<usize>()];
+        let mut send = vec![0usize; mem::size_of::<api::Events>() / mem::size_of::<usize>() + (max(2, len) - 2)];
 
         let send_events: &mut [*mut api::Event] = unsafe {
             let header = &mut *(send.as_mut_ptr() as *mut api::Events);
             header.num_events = len as i32;
-            slice::from_raw_parts_mut(&mut header.events, len)
+            slice::from_raw_parts_mut(&mut header.events[0], len)
         };
 
         // To send this array to the plugin, we need to convert events to the equivalent VST

--- a/src/host.rs
+++ b/src/host.rs
@@ -207,6 +207,9 @@ pub trait Host {
     fn get_info(&self) -> (isize, String, String) {
         (1, "vendor string".to_owned(), "product string".to_owned())
     }
+
+    /// Send MIDI events to the host (for VST plugins with MIDI output).
+    fn process_events(&mut self, events: Vec<Event>) {}
 }
 
 /// All possible errors that can occur when loading a VST plugin.

--- a/src/host.rs
+++ b/src/host.rs
@@ -5,7 +5,6 @@ use std::sync::{Arc, Mutex};
 use std::error::Error;
 use std::{fmt, mem, ptr, slice};
 use std::ffi::CString;
-use std::cmp::max;
 
 use libloading::Library;
 use libc::c_void;
@@ -209,7 +208,7 @@ pub trait Host {
         (1, "vendor string".to_owned(), "product string".to_owned())
     }
 
-    /// Send MIDI events to the host (for VST plugins with MIDI output).
+    /// Handle incoming events from the plugin.
     fn process_events(&mut self, events: Vec<Event>) {}
 }
 
@@ -589,78 +588,18 @@ impl Plugin for PluginInstance {
     }
 
     fn process_events(&mut self, events: Vec<Event>) {
-        use api::flags::REALTIME_EVENT;
-        use api;
-
-        let len = events.len();
-
-        let mut send = vec![0usize; mem::size_of::<api::Events>() / mem::size_of::<usize>() + (max(2, len) - 2)];
-
-        let send_events: &mut [*mut api::Event] = unsafe {
-            let header = &mut *(send.as_mut_ptr() as *mut api::Events);
-            header.num_events = len as i32;
-            slice::from_raw_parts_mut(&mut header.events[0], len)
-        };
-
-        // To send this array to the plugin, we need to convert events to the equivalent VST
-        // structures. Most of what's happening here is just copying data but the key thing to
-        // notice is that each event is boxed and casted to (*mut api::Event). This way we can let
-        // the plugin handle the event, and then later create the box again from the raw pointer so
-        // that it can be properly dropped.
-        for (event, out) in events.iter().zip(send_events.iter_mut()) {
-            *out = match *event {
-                Event::Midi { data, delta_frames, live,
-                              note_length, note_offset,
-                              detune, note_off_velocity } => {
-                    Box::into_raw(Box::new(api::MidiEvent {
-                        event_type: api::EventType::Midi,
-                        byte_size: mem::size_of::<api::MidiEvent>() as i32,
-                        delta_frames: delta_frames,
-                        flags: if live { REALTIME_EVENT.bits() } else { 0 },
-                        note_length: note_length.unwrap_or(0),
-                        note_offset: note_offset.unwrap_or(0),
-                        midi_data: data,
-                        _midi_reserved: 0,
-                        detune: detune,
-                        note_off_velocity: note_off_velocity,
-                        _reserved1: 0,
-                        _reserved2: 0
-                    })) as *mut api::Event
-                }
-                Event::SysEx { payload, delta_frames } => {
-                    Box::into_raw(Box::new(api::SysExEvent {
-                        event_type: api::EventType::SysEx,
-                        byte_size: mem::size_of::<api::SysExEvent>() as i32,
-                        delta_frames: delta_frames,
-                        _flags: 0,
-                        data_size: payload.len() as i32,
-                        _reserved1: 0,
-                        system_data: payload.as_ptr() as *const u8 as *mut u8,
-                        _reserved2: 0,
-                    })) as *mut api::Event
-                }
-                Event::Deprecated(e) => Box::into_raw(Box::new(e))
+        interfaces::process_events(
+            events,
+            |ptr| {
+                self.dispatch(
+                    plugin::OpCode::ProcessEvents,
+                    0,
+                    0,
+                    ptr,
+                    0.0
+                );
             }
-        }
-
-        self.dispatch(plugin::OpCode::ProcessEvents, 0, 0, send.as_mut_ptr() as *mut api::Events as *mut c_void, 0.0);
-
-        // Clean up the created events
-        unsafe {
-            for &mut event in send_events {
-                match (*event).event_type {
-                    api::EventType::Midi => {
-                        drop(Box::from_raw(event as *mut api::MidiEvent));
-                    }
-                    api::EventType::SysEx => {
-                        drop(Box::from_raw(event as *mut api::SysExEvent));
-                    }
-                    _ => {
-                        drop(Box::from_raw(event));
-                    }
-                }
-            }
-        }
+        );
     }
 
     // TODO: Editor

--- a/src/host.rs
+++ b/src/host.rs
@@ -593,13 +593,21 @@ impl Plugin for PluginInstance {
 
         let len = events.len();
 
+        let mut send = vec![0u8; 2 * mem::size_of::<i32>() + len * mem::size_of::<usize>()];
+
+        let send_events: &mut [*mut api::Event] = unsafe {
+            let header = &mut *(send.as_mut_ptr() as *mut api::Events);
+            header.num_events = len as i32;
+            slice::from_raw_parts_mut(&mut header.events, len)
+        };
+
         // To send this array to the plugin, we need to convert events to the equivalent VST
         // structures. Most of what's happening here is just copying data but the key thing to
         // notice is that each event is boxed and casted to (*mut api::Event). This way we can let
         // the plugin handle the event, and then later create the box again from the raw pointer so
         // that it can be properly dropped.
-        let mut events: Vec<*mut api::Event> = events.iter().map(|event| {
-            match *event {
+        for (event, out) in events.iter().zip(send_events.iter_mut()) {
+            *out = match *event {
                 Event::Midi { data, delta_frames, live,
                               note_length, note_offset,
                               detune, note_off_velocity } => {
@@ -632,19 +640,13 @@ impl Plugin for PluginInstance {
                 }
                 Event::Deprecated(e) => Box::into_raw(Box::new(e))
             }
-        }).collect();
+        }
 
-        let mut send = api::Events {
-            num_events: len as i32,
-            _reserved: 0,
-            events: events.as_mut_ptr()
-        };
-
-        self.dispatch(plugin::OpCode::ProcessEvents, 0, 0, &mut send as *mut api::Events as *mut c_void, 0.0);
+        self.dispatch(plugin::OpCode::ProcessEvents, 0, 0, send.as_mut_ptr() as *mut api::Events as *mut c_void, 0.0);
 
         // Clean up the created events
         unsafe {
-            for event in events {
+            for &mut event in send_events {
                 match (*event).event_type {
                     api::EventType::Midi => {
                         drop(Box::from_raw(event as *mut api::MidiEvent));

--- a/src/interfaces.rs
+++ b/src/interfaces.rs
@@ -174,7 +174,7 @@ pub fn dispatch(effect: *mut AEffect, opcode: i32, index: i32, value: isize, ptr
 
             let events: Vec<Event> = unsafe {
                 // Create a slice of type &mut [*mut Event]
-                slice::from_raw_parts(&(*events).events, (*events).num_events as usize)
+                slice::from_raw_parts(&(*events).events[0], (*events).num_events as usize)
                 // Deref and clone each event to get a slice
                 .iter().map(|item| Event::from(**item)).collect()
             };
@@ -294,7 +294,7 @@ pub fn host_dispatch(host: &mut Host,
 
             let events: Vec<Event> = unsafe {
                 // Create a slice of type &mut [*mut Event]
-                slice::from_raw_parts(&(*events).events, (*events).num_events as usize)
+                slice::from_raw_parts(&(*events).events[0], (*events).num_events as usize)
                 // Deref and clone each event to get a slice
                 .iter().map(|item| Event::from(**item)).collect()
             };

--- a/src/interfaces.rs
+++ b/src/interfaces.rs
@@ -289,6 +289,18 @@ pub fn host_dispatch(host: &mut Host,
         OpCode::GetVendorVersion => return host.get_info().0,
         OpCode::GetVendorString => copy_string(&host.get_info().1, MAX_VENDOR_STR_LEN),
         OpCode::GetProductString => copy_string(&host.get_info().2, MAX_PRODUCT_STR_LEN),
+        OpCode::ProcessEvents => {
+            let events: *const api::Events = ptr as *const api::Events;
+
+            let events: Vec<Event> = unsafe {
+                // Create a slice of type &mut [*mut Event]
+                slice::from_raw_parts((*events).events, (*events).num_events as usize)
+                // Deref and clone each event to get a slice
+                .iter().map(|item| Event::from(**item)).collect()
+            };
+
+            host.process_events(events);
+        }
 
         unimplemented => {
             trace!("VST: Got unimplemented host opcode ({:?})", unimplemented);

--- a/src/interfaces.rs
+++ b/src/interfaces.rs
@@ -174,7 +174,7 @@ pub fn dispatch(effect: *mut AEffect, opcode: i32, index: i32, value: isize, ptr
 
             let events: Vec<Event> = unsafe {
                 // Create a slice of type &mut [*mut Event]
-                slice::from_raw_parts((*events).events, (*events).num_events as usize)
+                slice::from_raw_parts(&(*events).events, (*events).num_events as usize)
                 // Deref and clone each event to get a slice
                 .iter().map(|item| Event::from(**item)).collect()
             };
@@ -294,7 +294,7 @@ pub fn host_dispatch(host: &mut Host,
 
             let events: Vec<Event> = unsafe {
                 // Create a slice of type &mut [*mut Event]
-                slice::from_raw_parts((*events).events, (*events).num_events as usize)
+                slice::from_raw_parts(&(*events).events, (*events).num_events as usize)
                 // Deref and clone each event to get a slice
                 .iter().map(|item| Event::from(**item)).collect()
             };

--- a/src/interfaces.rs
+++ b/src/interfaces.rs
@@ -317,3 +317,94 @@ fn read_string(ptr: *mut c_void) -> String {
         unsafe { CStr::from_ptr(ptr as *mut c_char).to_bytes() }
     ).into_owned()
 }
+
+/// Translate `Vec<Event>` into `&api::Events` and use via a callback.
+///
+/// Both plugins and hosts can receive VST events, this simply translates the rust structure into
+/// the equivalent API structure and takes care of cleanup.
+pub fn process_events<F>(events: Vec<Event>, callback: F)
+    where F: FnOnce(*mut c_void)
+{
+    use api::flags::REALTIME_EVENT;
+
+    let len = events.len();
+
+    // The `api::Events` structure uses a variable length array which is difficult to represent in
+    // rust. We begin by creating a vector with the appropriate byte size by calculating the header
+    // and the variable length body seperately.
+    let header_size = mem::size_of::<api::Events>() - (mem::size_of::<*mut api::Event>() * 2);
+    let body_size = mem::size_of::<*mut api::Event>() * len;
+
+    let mut send = vec![0u8; header_size + body_size];
+
+    let send_events: &mut [*mut api::Event] = unsafe {
+        // The header is updated by casting the array to the `api::Events` type and specifying the
+        // required fields. We create a slice from the position of the first event and the length
+        // of the array.
+        let ptr = send.as_mut_ptr() as *mut api::Events;
+        (*ptr).num_events = len as i32;
+
+        // A slice view of the body
+        slice::from_raw_parts_mut(&mut (*ptr).events[0], len)
+    };
+
+    // Each event is zipped with the target body array slot. Most of what's happening here is just
+    // copying data but the key thing to notice is that each event is boxed and cast to
+    // (*mut api::Event). This way we can let the callback handle the event, and then later create
+    // the box again from the raw pointer so that it can be properly dropped.
+    for (event, out) in events.iter().zip(send_events.iter_mut()) {
+        *out = match *event {
+            Event::Midi { data, delta_frames, live,
+                          note_length, note_offset,
+                          detune, note_off_velocity } => {
+                Box::into_raw(Box::new(api::MidiEvent {
+                    event_type: api::EventType::Midi,
+                    byte_size: mem::size_of::<api::MidiEvent>() as i32,
+                    delta_frames: delta_frames,
+                    flags: if live { REALTIME_EVENT.bits() } else { 0 },
+                    note_length: note_length.unwrap_or(0),
+                    note_offset: note_offset.unwrap_or(0),
+                    midi_data: data,
+                    _midi_reserved: 0,
+                    detune: detune,
+                    note_off_velocity: note_off_velocity,
+                    _reserved1: 0,
+                    _reserved2: 0
+                })) as *mut api::Event
+            }
+            Event::SysEx { payload, delta_frames } => {
+                Box::into_raw(Box::new(api::SysExEvent {
+                    event_type: api::EventType::SysEx,
+                    byte_size: mem::size_of::<api::SysExEvent>() as i32,
+                    delta_frames: delta_frames,
+                    _flags: 0,
+                    data_size: payload.len() as i32,
+                    _reserved1: 0,
+                    system_data: payload.as_ptr() as *const u8 as *mut u8,
+                    _reserved2: 0,
+                })) as *mut api::Event
+            }
+            Event::Deprecated(e) => Box::into_raw(Box::new(e))
+        };
+    }
+
+    // Allow the callback to use the pointer
+    callback(send.as_mut_ptr() as *mut c_void);
+
+    // Clean up the created events
+    unsafe {
+        for &mut event in send_events {
+            match (*event).event_type {
+                api::EventType::Midi => {
+                    drop(Box::from_raw(event as *mut api::MidiEvent));
+                }
+                api::EventType::SysEx => {
+                    drop(Box::from_raw(event as *mut api::SysExEvent));
+                }
+                _ => {
+                    drop(Box::from_raw(event));
+                }
+            }
+        }
+    }
+}

--- a/src/plugin.rs
+++ b/src/plugin.rs
@@ -1,6 +1,7 @@
 //! Plugin specific structures.
 
 use std::{mem, ptr, slice};
+use std::cmp::max;
 
 use libc::c_void;
 
@@ -819,12 +820,12 @@ impl Host for HostCallback {
 
         let len = events.len();
 
-        let mut send = vec![0u8; 2 * mem::size_of::<i32>() + len * mem::size_of::<usize>()];
+        let mut send = vec![0usize; mem::size_of::<api::Events>() / mem::size_of::<usize>() + (max(2, len) - 2)];
 
         let send_events: &mut [*mut api::Event] = unsafe {
             let header = &mut *(send.as_mut_ptr() as *mut api::Events);
             header.num_events = len as i32;
-            slice::from_raw_parts_mut(&mut header.events, len)
+            slice::from_raw_parts_mut(&mut header.events[0], len)
         };
 
         // To send this array to the plugin, we need to convert events to the equivalent VST

--- a/src/plugin.rs
+++ b/src/plugin.rs
@@ -1,7 +1,6 @@
 //! Plugin specific structures.
 
-use std::{mem, ptr, slice};
-use std::cmp::max;
+use std::{mem, ptr};
 
 use libc::c_void;
 
@@ -815,78 +814,21 @@ impl Host for HostCallback {
     }
 
     fn process_events(&mut self, events: Vec<Event>) {
-        use api::flags::REALTIME_EVENT;
-        use api;
+        use interfaces;
 
-        let len = events.len();
-
-        let mut send = vec![0usize; mem::size_of::<api::Events>() / mem::size_of::<usize>() + (max(2, len) - 2)];
-
-        let send_events: &mut [*mut api::Event] = unsafe {
-            let header = &mut *(send.as_mut_ptr() as *mut api::Events);
-            header.num_events = len as i32;
-            slice::from_raw_parts_mut(&mut header.events[0], len)
-        };
-
-        // To send this array to the plugin, we need to convert events to the equivalent VST
-        // structures. Most of what's happening here is just copying data but the key thing to
-        // notice is that each event is boxed and casted to (*mut api::Event). This way we can let
-        // the plugin handle the event, and then later create the box again from the raw pointer so
-        // that it can be properly dropped.
-        for (event, out) in events.iter().zip(send_events.iter_mut()) {
-            *out = match *event {
-                Event::Midi { data, delta_frames, live,
-                              note_length, note_offset,
-                              detune, note_off_velocity } => {
-                    Box::into_raw(Box::new(api::MidiEvent {
-                        event_type: api::EventType::Midi,
-                        byte_size: mem::size_of::<api::MidiEvent>() as i32,
-                        delta_frames: delta_frames,
-                        flags: if live { REALTIME_EVENT.bits() } else { 0 },
-                        note_length: note_length.unwrap_or(0),
-                        note_offset: note_offset.unwrap_or(0),
-                        midi_data: data,
-                        _midi_reserved: 0,
-                        detune: detune,
-                        note_off_velocity: note_off_velocity,
-                        _reserved1: 0,
-                        _reserved2: 0
-                    })) as *mut api::Event
-                }
-                Event::SysEx { payload, delta_frames } => {
-                    Box::into_raw(Box::new(api::SysExEvent {
-                        event_type: api::EventType::SysEx,
-                        byte_size: mem::size_of::<api::SysExEvent>() as i32,
-                        delta_frames: delta_frames,
-                        _flags: 0,
-                        data_size: payload.len() as i32,
-                        _reserved1: 0,
-                        system_data: payload.as_ptr() as *const u8 as *mut u8,
-                        _reserved2: 0,
-                    })) as *mut api::Event
-                }
-                Event::Deprecated(e) => Box::into_raw(Box::new(e))
+        interfaces::process_events(
+            events,
+            |ptr| {
+                self.callback(
+                    self.effect,
+                    host::OpCode::ProcessEvents,
+                    0,
+                    0,
+                    ptr,
+                    0.0
+                 );
             }
-        }
-
-        self.callback(self.effect, host::OpCode::ProcessEvents, 0, 0, send.as_mut_ptr() as *mut api::Events as *mut c_void, 0.0);
-
-        // Clean up the created events
-        unsafe {
-            for &mut event in send_events {
-                match (*event).event_type {
-                    api::EventType::Midi => {
-                        drop(Box::from_raw(event as *mut api::MidiEvent));
-                    }
-                    api::EventType::SysEx => {
-                        drop(Box::from_raw(event as *mut api::SysExEvent));
-                    }
-                    _ => {
-                        drop(Box::from_raw(event));
-                    }
-                }
-            }
-        }
+        );
     }
 }
 


### PR DESCRIPTION
As requested: https://github.com/overdrivenpotato/rust-vst2/issues/18
I haven't tested it yet but I implemented it because @suhr needed it, and he is gonna test it with his plugin.
So we should wait for his confirmation before merging this.
(I basically copy-pasted from Plugin to Host, maybe we should factor out the commonalities..)