### PR TITLE
Fixed a naming error in the MacOS build script.

### DIFF
--- a/osx_vst_bundler.sh
+++ b/osx_vst_bundler.sh
@@ -22,7 +22,7 @@ else
     <string>English</string>
 
     <key>CFBundleExecutable</key>
-    <string>vst</string>
+    <string>$1</string>
 
     <key>CFBundleGetInfoString</key>
     <string>vst</string>


### PR DESCRIPTION
This script doesn't work on MacOS unless your plugin is literally named 'vst'. Most DAWs won't report an error directly and fail silently, but those that do print the error to console `Cannot find executable for CFBundle`.

I found changing the name of the CFBundleExecutable key to the binary name fixed the problem.