### PR TITLE
Update libraries to their latest minor version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,5 +16,5 @@ keywords = ["vst", "vst2", "plugin"]
 log = "0.3"
 num-traits = "0.1"
 libc = "0.2"
-bitflags = "0.7"
-libloading = "0.3"
+bitflags = "0.8"
+libloading = "0.4"


### PR DESCRIPTION
Specifically, libloading 0.3 -> 0.4 and bitflags 0.7 -> 0.8.

I ran `cargo test` (passing) and also verified that this change is non-breaking on my own VST effect.