### PR TITLE
Use types from std::os::raw instead of libc where possible

### DIFF
--- a/examples/sine_synth/Cargo.toml
+++ b/examples/sine_synth/Cargo.toml
@@ -8,4 +8,4 @@ vst2 = { git = "https://github.com/overdrivenpotato/rust-vst2" }
 
 [lib]
 name = "sine_synth"
-crate-type = ["dylib"]
+crate-type = ["cdylib"]

--- a/examples/sine_synth/src/lib.rs
+++ b/examples/sine_synth/src/lib.rs
@@ -1,8 +1,9 @@
 #[macro_use] extern crate vst2;
 
 use vst2::buffer::AudioBuffer;
-use vst2::plugin::{Category, Plugin, Info};
-use vst2::event::{Event};
+use vst2::plugin::{Category, Plugin, Info, CanDo};
+use vst2::event::Event;
+use vst2::api::Supported;
 
 use std::f64::consts::PI;
 
@@ -136,6 +137,13 @@ impl Plugin for SineSynth {
 
         self.time += samples as f64 * per_sample;
         self.note_duration += samples as f64 * per_sample;
+    }
+
+    fn can_do(&self, can_do: CanDo) -> Supported {
+        match can_do {
+            CanDo::ReceiveMidiEvent => Supported::Yes,
+            _ => Supported::Maybe
+        }
     }
 }
 

--- a/src/api.rs
+++ b/src/api.rs
@@ -1,7 +1,7 @@
 //! Structures and types for interfacing with the VST 2.4 API.
 use std::mem;
 
-use libc::c_void;
+use std::os::raw::c_void;
 
 use plugin::Plugin;
 use self::consts::*;
@@ -9,14 +9,13 @@ use self::consts::*;
 /// Constant values
 #[allow(missing_docs)] // For obvious constants
 pub mod consts {
-    use libc::size_t;
 
-    pub const MAX_PRESET_NAME_LEN: size_t = 24;
-    pub const MAX_PARAM_STR_LEN: size_t = 32;
+    pub const MAX_PRESET_NAME_LEN: usize = 24;
+    pub const MAX_PARAM_STR_LEN: usize = 32;
     pub const MAX_LABEL: usize = 64;
     pub const MAX_SHORT_LABEL: usize = 8;
-    pub const MAX_PRODUCT_STR_LEN: size_t = 64;
-    pub const MAX_VENDOR_STR_LEN: size_t = 64;
+    pub const MAX_PRODUCT_STR_LEN: usize = 64;
+    pub const MAX_VENDOR_STR_LEN: usize = 64;
 
     /// VST plugins are identified by a magic number. This corresponds to 0x56737450.
     pub const VST_MAGIC: i32 = ('V' as i32) << 24 |

--- a/src/editor.rs
+++ b/src/editor.rs
@@ -1,6 +1,6 @@
 //! All VST plugin editor related functionality.
 
-use libc::c_void;
+use std::os::raw::c_void;
 
 /// Implemented by plugin editors.
 #[allow(unused_variables)]

--- a/src/interfaces.rs
+++ b/src/interfaces.rs
@@ -2,11 +2,9 @@
 
 #![doc(hidden)]
 
-use std::ffi::{CStr, CString};
 use std::{mem, slice};
 
 use std::os::raw::{c_char, c_void};
-use libc::strncpy;
 
 use buffer::AudioBuffer;
 use api::consts::*;
@@ -61,6 +59,18 @@ pub fn get_parameter(effect: *mut AEffect, index: i32) -> f32 {
     unsafe { (*effect).get_plugin() }.get_parameter(index)
 }
 
+// Copy a string into the `ptr` buffer
+fn copy_string(dst: *mut c_void, src: &str, max: usize) {
+    unsafe {
+        use std::cmp::min;
+        use libc::{c_void, memset, memcpy};
+
+        let dst = dst as *mut c_void;
+        memset(dst, 0, max);
+        memcpy(dst, src.as_ptr() as *const c_void, min(max, src.len()));
+    }
+}
+
 /// VST2.4 dispatch function. This function handles dispatching all opcodes to the vst plugin.
 pub fn dispatch(effect: *mut AEffect, opcode: i32, index: i32, value: isize, ptr: *mut c_void, opt: f32) -> isize {
     use plugin::{CanDo, OpCode};
@@ -69,15 +79,6 @@ pub fn dispatch(effect: *mut AEffect, opcode: i32, index: i32, value: isize, ptr
     let opcode = OpCode::from(opcode);
     // Plugin handle
     let mut plugin = unsafe { (*effect).get_plugin() };
-
-    // Copy a string into the `ptr` buffer
-    let copy_string = |string: &String, max: usize| {
-        unsafe {
-            strncpy(ptr as *mut c_char,
-                          CString::new(string.clone()).unwrap().as_ptr(),
-                          max);
-        }
-    };
 
     match opcode {
         OpCode::Initialize => plugin.init(),
@@ -91,12 +92,12 @@ pub fn dispatch(effect: *mut AEffect, opcode: i32, index: i32, value: isize, ptr
         OpCode::SetCurrentPresetName => plugin.set_preset_name(read_string(ptr)),
         OpCode::GetCurrentPresetName => {
             let num = plugin.get_preset_num();
-            copy_string(&plugin.get_preset_name(num), MAX_PRESET_NAME_LEN);
+            copy_string(ptr, &plugin.get_preset_name(num), MAX_PRESET_NAME_LEN);
         }
 
-        OpCode::GetParameterLabel => copy_string(&plugin.get_parameter_label(index), MAX_PARAM_STR_LEN),
-        OpCode::GetParameterDisplay => copy_string(&plugin.get_parameter_text(index), MAX_PARAM_STR_LEN),
-        OpCode::GetParameterName => copy_string(&plugin.get_parameter_name(index), MAX_PARAM_STR_LEN),
+        OpCode::GetParameterLabel => copy_string(ptr, &plugin.get_parameter_label(index), MAX_PARAM_STR_LEN),
+        OpCode::GetParameterDisplay => copy_string(ptr, &plugin.get_parameter_text(index), MAX_PARAM_STR_LEN),
+        OpCode::GetParameterName => copy_string(ptr, &plugin.get_parameter_name(index), MAX_PARAM_STR_LEN),
 
         OpCode::SetSampleRate => plugin.set_sample_rate(opt),
         OpCode::SetBlockSize => plugin.set_block_size(value as i64),
@@ -185,7 +186,7 @@ pub fn dispatch(effect: *mut AEffect, opcode: i32, index: i32, value: isize, ptr
         OpCode::CanBeAutomated => return plugin.can_be_automated(index) as isize,
         OpCode::StringToParameter => return plugin.string_to_parameter(index, read_string(ptr)) as isize,
 
-        OpCode::GetPresetName => copy_string(&plugin.get_preset_name(index), MAX_PRESET_NAME_LEN),
+        OpCode::GetPresetName => copy_string(ptr, &plugin.get_preset_name(index), MAX_PRESET_NAME_LEN),
 
         OpCode::GetInputInfo => {
             if index >= 0 && index < plugin.get_info().inputs {
@@ -207,8 +208,8 @@ pub fn dispatch(effect: *mut AEffect, opcode: i32, index: i32, value: isize, ptr
             return plugin.get_info().category.into();
         }
 
-        OpCode::GetVendorName => copy_string(&plugin.get_info().vendor, MAX_VENDOR_STR_LEN),
-        OpCode::GetProductName => copy_string(&plugin.get_info().name, MAX_PRODUCT_STR_LEN),
+        OpCode::GetVendorName => copy_string(ptr, &plugin.get_info().vendor, MAX_VENDOR_STR_LEN),
+        OpCode::GetProductName => copy_string(ptr, &plugin.get_info().name, MAX_PRODUCT_STR_LEN),
         OpCode::GetVendorVersion => return plugin.get_info().version as isize,
         OpCode::VendorSpecific => return plugin.vendor_specific(index, value, ptr, opt),
         OpCode::CanDo => {
@@ -266,15 +267,6 @@ pub fn host_dispatch(host: &mut Host,
                      opt: f32) -> isize {
     use host::OpCode;
 
-    // Copy a string into the `ptr` buffer
-    let copy_string = |string: &String, max: usize| {
-        unsafe {
-            strncpy(ptr as *mut c_char,
-                          CString::new(string.clone()).unwrap().as_ptr(),
-                          max);
-        }
-    };
-
     match OpCode::from(opcode) {
         OpCode::Version => return 2400,
         OpCode::Automate => host.automate(index, opt),
@@ -288,8 +280,8 @@ pub fn host_dispatch(host: &mut Host,
         }
 
         OpCode::GetVendorVersion => return host.get_info().0,
-        OpCode::GetVendorString => copy_string(&host.get_info().1, MAX_VENDOR_STR_LEN),
-        OpCode::GetProductString => copy_string(&host.get_info().2, MAX_PRODUCT_STR_LEN),
+        OpCode::GetVendorString => copy_string(ptr, &host.get_info().1, MAX_VENDOR_STR_LEN),
+        OpCode::GetProductString => copy_string(ptr, &host.get_info().2, MAX_PRODUCT_STR_LEN),
         OpCode::ProcessEvents => {
             let events: *const api::Events = ptr as *const api::Events;
 
@@ -314,6 +306,8 @@ pub fn host_dispatch(host: &mut Host,
 
 // Read a string from the `ptr` buffer
 fn read_string(ptr: *mut c_void) -> String {
+    use std::ffi::CStr;
+
     String::from_utf8_lossy(
         unsafe { CStr::from_ptr(ptr as *mut c_char).to_bytes() }
     ).into_owned()

--- a/src/interfaces.rs
+++ b/src/interfaces.rs
@@ -59,7 +59,9 @@ pub fn get_parameter(effect: *mut AEffect, index: i32) -> f32 {
     unsafe { (*effect).get_plugin() }.get_parameter(index)
 }
 
-// Copy a string into the `ptr` buffer
+/// Copy a string into a destination buffer.
+///
+/// String will be cut at `max` characters.
 fn copy_string(dst: *mut c_void, src: &str, max: usize) {
     unsafe {
         use std::cmp::min;

--- a/src/interfaces.rs
+++ b/src/interfaces.rs
@@ -5,7 +5,8 @@
 use std::ffi::{CStr, CString};
 use std::{mem, slice};
 
-use libc::{self, size_t, c_char, c_void};
+use std::os::raw::{c_char, c_void};
+use libc::strncpy;
 
 use buffer::AudioBuffer;
 use api::consts::*;
@@ -70,9 +71,9 @@ pub fn dispatch(effect: *mut AEffect, opcode: i32, index: i32, value: isize, ptr
     let mut plugin = unsafe { (*effect).get_plugin() };
 
     // Copy a string into the `ptr` buffer
-    let copy_string = |string: &String, max: size_t| {
+    let copy_string = |string: &String, max: usize| {
         unsafe {
-            libc::strncpy(ptr as *mut c_char,
+            strncpy(ptr as *mut c_char,
                           CString::new(string.clone()).unwrap().as_ptr(),
                           max);
         }
@@ -266,9 +267,9 @@ pub fn host_dispatch(host: &mut Host,
     use host::OpCode;
 
     // Copy a string into the `ptr` buffer
-    let copy_string = |string: &String, max: size_t| {
+    let copy_string = |string: &String, max: usize| {
         unsafe {
-            libc::strncpy(ptr as *mut c_char,
+            strncpy(ptr as *mut c_char,
                           CString::new(string.clone()).unwrap().as_ptr(),
                           max);
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -252,7 +252,7 @@ pub fn main<T: Plugin + Default>(callback: HostCallbackProc) -> *mut AEffect {
 mod tests {
     use std::ptr;
 
-    use libc::c_void;
+    use std::os::raw::c_void;
 
     use interfaces;
     use api::AEffect;

--- a/src/plugin.rs
+++ b/src/plugin.rs
@@ -2,7 +2,7 @@
 
 use std::{mem, ptr};
 
-use libc::c_void;
+use std::os::raw::c_void;
 
 use channels::ChannelInfo;
 use host::{self, Host};

--- a/src/plugin.rs
+++ b/src/plugin.rs
@@ -850,7 +850,7 @@ mod tests {
     /// This is a macro to allow you to specify attributes on the created struct.
     macro_rules! make_plugin {
         ($($attr:meta) *) => {
-            use libc::c_void;
+            use std::os::raw::c_void;
 
             use main;
             use api::AEffect;


### PR DESCRIPTION
Now plugins don't need to depend on libc for `Plugin::open()`.

I also made `load_pointer` uppercase (`LOAD_POINTER`) because it's a global var and caused a warning.