### PR TITLE
Reworked AudioBuffer, removed memory allocations in the audio thread,…

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,3 +18,6 @@ num-traits = "0.1"
 libc = "0.2"
 bitflags = "0.8"
 libloading = "0.4"
+
+[features]
+nightly = []

--- a/examples/dimension_expander/Cargo.toml
+++ b/examples/dimension_expander/Cargo.toml
@@ -4,9 +4,9 @@ version = "0.1.0"
 authors = ["Marko Mijalkovic <marko.mijalkovic97@gmail.com>"]
 
 [dependencies]
-vst2 = { git = "https://github.com/overdrivenpotato/rust-vst2" }
+vst2 = { path = "../.." }
 time = "0.1"
 
 [lib]
 name = "dimension_expander"
-crate-type = ["dylib"]
+crate-type = ["cdylib"]

--- a/examples/dimension_expander/src/lib.rs
+++ b/examples/dimension_expander/src/lib.rs
@@ -139,8 +139,7 @@ impl Plugin for DimensionExpander {
             _ => (),
         }
     }
-
-    fn process(&mut self, buffer: AudioBuffer<f32>) {
+    fn process(&mut self, buffer: &mut AudioBuffer<f32>) {
         let (inputs, mut outputs) = buffer.split();
 
         // Assume 2 channels
@@ -149,14 +148,12 @@ impl Plugin for DimensionExpander {
         }
 
         // Iterate over inputs as (&f32, &f32)
-        let stereo_in = match inputs.split_at(1) {
-            (l, r) => l[0].iter().zip(r[0].iter())
-        };
+        let (l, r) = inputs.split_at(1);
+        let stereo_in = l[0].iter().zip(r[0].iter());
 
         // Iterate over outputs as (&mut f32, &mut f32)
-        let stereo_out = match outputs.split_at_mut(1) {
-            (l, r) => l[0].iter_mut().zip(r[0].iter_mut())
-        };
+        let (mut l, mut r) = outputs.split_at_mut(1);
+        let stereo_out = l[0].iter_mut().zip(r[0].iter_mut());
 
         // Zip and process
         for ((left_in, right_in), (left_out, right_out)) in stereo_in.zip(stereo_out) {

--- a/examples/sine_synth/Cargo.toml
+++ b/examples/sine_synth/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 authors = ["Rob Saunders <hello@robsaunders.io>"]
 
 [dependencies]
-vst2 = { git = "https://github.com/overdrivenpotato/rust-vst2" }
+vst2 = { path = "../.." }
 
 [lib]
 name = "sine_synth"

--- a/examples/sine_synth/src/lib.rs
+++ b/examples/sine_synth/src/lib.rs
@@ -92,7 +92,7 @@ impl Plugin for SineSynth {
         for &e in events.events_raw() {
             let event: Event = Event::from(unsafe { *e });
             match event {
-                Event::Midi { data, .. } => self.process_midi_event(data),
+                Event::Midi(ev) => self.process_midi_event(ev.data),
                 // More events can be handled here.
                 _ => ()
             }

--- a/examples/sine_synth/src/lib.rs
+++ b/examples/sine_synth/src/lib.rs
@@ -89,6 +89,15 @@ impl Plugin for SineSynth {
 
     #[allow(unused_variables)]
     fn process_events(&mut self, events: &Events) {
+        for &e in events.events_raw() {
+            let event: Event = Event::from(unsafe { *e });
+            match event {
+                Event::Midi { data, .. } => self.process_midi_event(data),
+                // More events can be handled here.
+                _ => ()
+            }
+        }
+        /* on nightly you can just enable the "nightly" feature and then do:
         for event in events.events() {
             match event {
                 Event::Midi { data, ..  } => self.process_midi_event(data),
@@ -96,6 +105,7 @@ impl Plugin for SineSynth {
                 _ => {}
             }
         }
+        */
     }
 
     fn set_sample_rate(&mut self, rate: f32) {

--- a/examples/sine_synth/src/lib.rs
+++ b/examples/sine_synth/src/lib.rs
@@ -3,17 +3,18 @@
 use vst2::buffer::AudioBuffer;
 use vst2::plugin::{Category, Plugin, Info, CanDo};
 use vst2::event::Event;
-use vst2::api::Supported;
+use vst2::api::{Supported, Events};
 
 use std::f64::consts::PI;
 
-/// Convert the midi note into the equivalent frequency.
+/// Convert the midi note's pitch into the equivalent frequency.
 ///
 /// This function assumes A4 is 440hz.
-fn midi_note_to_hz(note: u8) -> f64 {
-    const A4: f64 = 440.0;
+fn midi_pitch_to_freq(pitch: u8) -> f64 {
+    const A4_PITCH: u8 = 69;
+    const A4_FREQ: f64 = 440.0;
 
-    (A4 / 32.0) * ((note as f64 - 9.0) / 12.0).exp2()
+    (((pitch - A4_PITCH) as f64) / 12.).exp2() * A4_FREQ
 }
 
 struct SineSynth {
@@ -87,8 +88,8 @@ impl Plugin for SineSynth {
     }
 
     #[allow(unused_variables)]
-    fn process_events(&mut self, events: Vec<Event>) {
-        for event in events {
+    fn process_events(&mut self, events: &Events) {
+        for event in events.events() {
             match event {
                 Event::Midi { data, ..  } => self.process_midi_event(data),
                 // More events can be handled here.
@@ -101,22 +102,17 @@ impl Plugin for SineSynth {
         self.sample_rate = rate as f64;
     }
 
-    fn process(&mut self, buffer: AudioBuffer<f32>) {
-        let (inputs, outputs) = buffer.split();
-
-        let samples = inputs
-            .first()
-            .map(|channel| channel.len())
-            .unwrap_or(0);
+    fn process(&mut self, buffer: &mut AudioBuffer<f32>) {
+        let samples = buffer.samples();
 
         let per_sample = self.time_per_sample();
 
-        for (input_buffer, output_buffer) in inputs.iter().zip(outputs) {
+        for (input_buffer, output_buffer) in buffer.zip() {
             let mut t = self.time;
 
             for (_, output_sample) in input_buffer.iter().zip(output_buffer) {
                 if let Some(current_note) = self.note {
-                    let signal = (t * midi_note_to_hz(current_note) * TAU).sin();
+                    let signal = (t * midi_pitch_to_freq(current_note) * TAU).sin();
 
                     // Apply a quick envelope to the attack of the signal to avoid popping.
                     let attack = 0.5;

--- a/src/api.rs
+++ b/src/api.rs
@@ -420,7 +420,7 @@ impl Events {
     ///     for &e in events.events_raw() {
     ///         let event: Event = Event::from(unsafe { *e });
     ///         match event {
-    ///             Event::Midi { data, .. } => {
+    ///             Event::Midi(ev) => {
     ///                 // ...
     ///             }
     ///             _ => ()

--- a/src/api.rs
+++ b/src/api.rs
@@ -435,6 +435,12 @@ impl Events {
         unsafe { slice::from_raw_parts(&self.events[0] as *const *mut _ as *const *const _, self.num_events as usize) }
     }
 
+    #[inline(always)]
+    pub(crate) fn events_raw_mut(&mut self) -> &mut [*const SysExEvent] {
+        use std::slice;
+        unsafe { slice::from_raw_parts_mut(&mut self.events[0] as *mut *mut _ as *mut *const _, self.num_events as usize) }
+    }
+
     /// Use this in your impl of process_events() to process the incoming midi events (on nightly).
     ///
     /// # Example
@@ -601,6 +607,7 @@ pub struct MidiEvent {
 /// `plugin::CanDo` has a `ReceiveSysExEvent` variant which lets the host query the plugin as to
 /// whether this event is supported.
 #[repr(C)]
+#[derive(Clone)]
 pub struct SysExEvent {
     /// Should be `EventType::SysEx`.
     pub event_type: EventType,

--- a/src/api.rs
+++ b/src/api.rs
@@ -402,16 +402,40 @@ pub struct Events {
     pub events: [*mut Event; 2],
 }
 
-use event;
-
 impl Events {
+    /// Use this in your impl of process_events() to process the incoming midi events (on stable).
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use vst2::plugin::{Info, Plugin, HostCallback};
+    /// # use vst2::buffer::{AudioBuffer, SendEventBuffer};
+    /// # use vst2::host::Host;
+    /// # use vst2::api;
+    /// # use vst2::event::Event;
+    /// # struct ExamplePlugin { host: HostCallback, send_buf: SendEventBuffer }
+    /// # impl Plugin for ExamplePlugin {
+    /// #     fn get_info(&self) -> Info { Default::default() }
+    /// #
+    /// fn process_events(&mut self, events: &api::Events) {
+    ///     for &e in events.events_raw() {
+    ///         let event: Event = Event::from(unsafe { *e });
+    ///         match event {
+    ///             Event::Midi { data, .. } => {
+    ///                 // ...
+    ///             }
+    ///             _ => ()
+    ///         }
+    ///     }
+    /// }
+    /// # }
+    /// ```
     #[inline(always)]
-    fn events_raw(&self) -> &[*const Event] {
+    pub fn events_raw(&self) -> &[*const Event] {
         use std::slice;
         unsafe { slice::from_raw_parts(&self.events[0] as *const *mut _ as *const *const _, self.num_events as usize) }
     }
 
-    /// Use this in your impl of process_events() to process the incoming midi events.
+    /// Use this in your impl of process_events() to process the incoming midi events (on nightly).
     ///
     /// # Example
     /// ```no_run
@@ -436,9 +460,10 @@ impl Events {
     /// }
     /// # }
     /// ```
+    #[cfg(feature = "nightly")]
     #[inline(always)]
-    pub fn events<'a>(&'a self) -> impl Iterator<Item = event::Event> + 'a {
-        self.events_raw().into_iter().map(|&e| event::Event::from(unsafe { *e }))
+    pub fn events<'a>(&'a self) -> impl Iterator<Item = ::event::Event> + 'a {
+        self.events_raw().into_iter().map(|&e| ::event::Event::from(unsafe { *e }))
     }
 }
 

--- a/src/buffer.rs
+++ b/src/buffer.rs
@@ -222,6 +222,7 @@ use std::mem;
 /// This buffer is used for sending midi events through the VST interface.
 /// The purpose of this is to convert outgoing midi events from event::Event to api::Events.
 /// It only allocates memory in new() and reuses the memory between calls.
+#[derive(Default)]
 pub struct SendEventBuffer {
     buf: Vec<u8>,
 }

--- a/src/buffer.rs
+++ b/src/buffer.rs
@@ -260,7 +260,7 @@ impl SendEventBuffer {
     /// }
     /// # }
     /// ```
-    pub fn send<F: FnOnce(&api::Events)>(&mut self, events: Vec<Event>, callback: F) {
+    pub fn send<F: FnOnce(&api::Events)>(&mut self, events: &[Event], callback: F) {
         use std::cmp::min;
         use api::flags::REALTIME_EVENT;
 
@@ -285,7 +285,7 @@ impl SendEventBuffer {
         // copying data but the key thing to notice is that each event is boxed and cast to
         // (*mut api::Event). This way we can let the callback handle the event, and then later create
         // the box again from the raw pointer so that it can be properly dropped.
-        for (event, out) in events.into_iter().zip(send_events.iter_mut()) {
+        for (&event, out) in events.into_iter().zip(send_events.iter_mut()) {
             *out = match event {
                 Event::Midi { data, delta_frames, live,
                               note_length, note_offset,

--- a/src/buffer.rs
+++ b/src/buffer.rs
@@ -1,145 +1,343 @@
 //! Buffers to safely work with audio samples.
 
-use std::iter::{Zip, IntoIterator};
-use std::vec::IntoIter;
-use std::slice;
-
 use num_traits::Float;
 
-/// A buffer containing `ChannelBuffer` buffers for each input/output.
+use std::slice;
+use std::iter::Zip;
+
+/// AudioBuffer contains references to the audio buffers for all input and output channels
 pub struct AudioBuffer<'a, T: 'a + Float> {
-    inputs: Vec<&'a mut [T]>,
-    outputs: Vec<&'a mut [T]>,
+    inputs: &'a [*const T],
+    outputs: &'a mut [*mut T],
+    samples: usize,
 }
 
-/// Iterator over channel buffers for either inputs or outputs.
-pub type ChannelBufferIter<'a, T> = IntoIter<&'a mut [T]>;
-
 impl<'a, T: 'a + Float> AudioBuffer<'a, T> {
-    /// Create an `AudioBuffer` from vectors of slices.
-    ///
-    /// Each vector item represents either an input or output, and contains an array of samples. Eg
-    /// if inputs was a vector of size 2 containing slices of size 512, it would hold 2 inputs where
-    /// each input holds 512 samples.
-    pub fn new(inputs: Vec<&'a mut [T]>, outputs: Vec<&'a mut [T]>) -> AudioBuffer<'a, T> {
-        AudioBuffer {
+
+    /// Create an `AudioBuffer` from slices of raw pointers. Uuseful in a Rust VST host.
+    #[inline(always)]
+    pub fn new(inputs: &'a [*const T], outputs: &'a mut [*mut T], samples: usize) -> Self {
+        Self {
             inputs: inputs,
             outputs: outputs,
+            samples: samples,
         }
     }
 
-    /// Create an `AudioBuffer` from raw pointers. Only really useful for interacting with the VST
-    /// API.
-    pub unsafe fn from_raw(inputs_raw: *mut *mut T, outputs_raw: *mut *mut T, num_inputs: usize, num_outputs: usize, samples: usize) -> AudioBuffer<'a, T> {
-        let inputs =
-            // Create a slice of type &mut [*mut f32]
-            slice::from_raw_parts_mut(inputs_raw, num_inputs).iter()
-            // Convert to &mut [&mut [f32]]
-            .map(|input| slice::from_raw_parts_mut(*input, samples))
-            // Collect into Vec<&mut [f32]>
-            .collect();
-
-        let outputs =
-            // Create a slice of type &mut [*mut f32]
-            slice::from_raw_parts_mut(outputs_raw, num_outputs).iter()
-            // Convert to &mut [&mut [f32]]
-            .map(|output| slice::from_raw_parts_mut(*output, samples))
-            // Collect into Vec<&mut [f32]>
-            .collect();
-
-        // Call constructor with vectors
-        AudioBuffer::new(inputs, outputs)
+    /// Create an `AudioBuffer` from raw pointers. Only really useful for interacting with the VST API.
+    #[inline(always)]
+    pub fn from_raw(input_count: usize, output_count: usize,
+                    inputs_raw: *const *const T, outputs_raw: *mut *mut T, samples: usize) -> Self {
+        Self {
+            inputs: unsafe { slice::from_raw_parts(inputs_raw, input_count) },
+            outputs: unsafe { slice::from_raw_parts_mut(outputs_raw, output_count) },
+            samples: samples,
+        }
     }
 
-    /// Return a reference to all inputs.
-    pub fn inputs(&'a mut self) -> &'a mut Vec<&'a mut [T]> {
-        &mut self.inputs
-    }
+    /// The number of input channels that this buffer was created for
+    #[inline(always)]
+    pub fn input_count(&self) -> usize { self.inputs.len() }
 
-    /// Return a reference to all outputs.
-    pub fn outputs(&'a mut self) -> &'a mut Vec<&'a mut [T]> {
-        &mut self.outputs
-    }
+    /// The number of output channels that this buffer was created for
+    #[inline(always)]
+    pub fn output_count(&self) -> usize { self.outputs.len() }
 
-    /// Consume this buffer and split it into separate inputs and outputs.
-    ///
-    /// # Example
-    ///
-    /// ```
-    /// # use vst2::buffer::AudioBuffer;
-    /// # let mut in1 = vec![0.0; 512];
-    /// # let (mut in2, mut out1, mut out2) = (in1.clone(), in1.clone(), in1.clone());
-    /// #
-    /// # let buffer = AudioBuffer::new(vec![&mut in1, &mut in2],
-    /// #                               vec![&mut out1, &mut out2]);
-    /// let (mut inputs, mut outputs) = buffer.split();
-    /// let input: &mut [f32] = &mut inputs[0]; // First input
-    /// ```
-    pub fn split(self) -> (Vec<&'a mut [T]>, Vec<&'a mut [T]>) {
-        (self.inputs, self.outputs)
+    /// The number of samples in this buffer (same for all channels)
+    #[inline(always)]
+    pub fn samples(&self) -> usize { self.samples }
+
+    /// The raw inputs to pass to processReplacing
+    #[inline(always)]
+    pub(crate) fn raw_inputs(&self) -> &[*const T] { &self.inputs }
+
+    /// The raw outputs to pass to processReplacing
+    #[inline(always)]
+    pub(crate) fn raw_outputs(&mut self) -> &mut [*mut T] { &mut self.outputs }
+
+    /// Split this buffer into separate inputs and outputs.
+    #[inline(always)]
+    pub fn split<'b>(&'b mut self) -> (Inputs<'b, T>, Outputs<'b, T>) where 'a: 'b {
+        (
+            Inputs { bufs: &self.inputs, samples: self.samples },
+            Outputs { bufs: &self.outputs, samples: self.samples }
+        )
     }
 
     /// Zip together buffers.
-    pub fn zip(self) -> Zip<ChannelBufferIter<'a, T>, ChannelBufferIter<'a, T>> {
-        self.inputs.into_iter().zip(self.outputs.into_iter())
+    #[inline(always)]
+    pub fn zip<'b>(&'b mut self) -> Zip<InputIterator<'b, T>, OutputIterator<'b, T>> where 'a: 'b {
+        let (inputs, outputs) = self.split();
+        inputs.into_iter().zip(outputs)
     }
 }
 
-#[cfg(test)]
-mod tests {
-    use buffer::AudioBuffer;
+use std::ops::{Index, IndexMut};
 
-    /// Size of buffers used in tests.
-    const SIZE: usize = 1024;
+/// Wrapper type to access the buffers for the input channels of an AudioBuffer in a safe way.
+/// Behaves like a slice.
+#[derive(Copy, Clone)]
+pub struct Inputs<'a, T: 'a> {
+    bufs: &'a [*const T],
+    samples: usize,
+}
 
-    /// Test that creating and zipping buffers works.
-    ///
-    /// This test creates a channel for 2 inputs and 2 outputs. The input channels are simply values
-    /// from 0 to `SIZE-1` (e.g. [0, 1, 2, 3, 4, .. , SIZE - 1]) and the output channels are just 0.
-    /// This test assures that when the buffers are zipped together, the input values do not change.
-    #[test]
-    fn buffer_zip() {
-        let mut in1: Vec<f32> = (0..SIZE).map(|x| x as f32).collect();
-        let mut in2 = in1.clone();
+impl<'a, T> Inputs<'a, T> {
 
-        let mut out1 = vec![0.0; SIZE];
-        let mut out2 = out1.clone();
+    /// Number of channels
+    pub fn len(&self) -> usize { self.bufs.len() }
 
-        let buffer = AudioBuffer::new(vec![&mut in1, &mut in2],
-                                      vec![&mut out1, &mut out2]);
+    /// Access channel at the given index, unchecked
+    pub fn get(&self, i: usize) -> &'a [T] {
+        unsafe { slice::from_raw_parts(self.bufs[i], self.samples) }
+    }
 
-        for (input, output) in buffer.zip() {
-            input.into_iter().zip(output.into_iter())
-            .fold(0, |acc, (input, output)| {
-                assert_eq!(*input - acc as f32, 0.0);
-                assert_eq!(*output, 0.0);
-                acc + 1
-            });
+    /// Split borrowing at the given index, like for slices
+    pub fn split_at(&self, i: usize) -> (Inputs<'a, T>, Inputs<'a, T>) {
+        let (l, r) = self.bufs.split_at(i);
+        (
+            Inputs { bufs: &l, samples: self.samples },
+            Inputs { bufs: &r, samples: self.samples }
+        )
+    }
+}
+
+impl<'a, T> Index<usize> for Inputs<'a, T> {
+    type Output = [T];
+
+    fn index(&self, i: usize) -> &Self::Output {
+        self.get(i)
+    }
+}
+
+/// Iterator over buffers for input channels of an AudioBuffer.
+pub struct InputIterator<'a, T: 'a> {
+    data: Inputs<'a, T>,
+    i: usize,
+}
+
+impl<'a, T> Iterator for InputIterator<'a, T> {
+    type Item = &'a [T];
+
+    fn next(&mut self) -> Option<Self::Item> {
+        if self.i < self.data.len() {
+            let val = self.data.get(self.i);
+            self.i += 1;
+            Some(val)
+        } else {
+            None
+        }
+    }
+}
+
+impl<'a, T: Sized> IntoIterator for Inputs<'a, T> {
+    type Item = &'a [T];
+    type IntoIter = InputIterator<'a, T>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        InputIterator { data: self, i: 0 }
+    }
+}
+
+/// Wrapper type to access the buffers for the output channels of an AudioBuffer in a safe way.
+/// Behaves like a slice.
+#[derive(Copy, Clone)]
+pub struct Outputs<'a, T: 'a> {
+    bufs: &'a [*mut T],
+    samples: usize,
+}
+
+impl<'a, T> Outputs<'a, T> {
+
+    /// Number of channels
+    pub fn len(&self) -> usize { self.bufs.len() }
+
+    /// Access channel at the given index, unchecked
+    pub fn get(&self, i: usize) -> &'a [T] {
+        unsafe { slice::from_raw_parts(self.bufs[i], self.samples) }
+    }
+
+    /// Mutably access channel at the given index, unchecked
+    pub fn get_mut(&self, i: usize) -> &'a mut [T] {
+        unsafe { slice::from_raw_parts_mut(self.bufs[i], self.samples) }
+    }
+
+    /// Split borrowing at the given index, like for slices
+    pub fn split_at_mut(&mut self, i: usize) -> (Outputs<'a, T>, Outputs<'a, T>) {
+        let (l, r) = self.bufs.split_at(i);
+        (
+            Outputs { bufs: &l, samples: self.samples },
+            Outputs { bufs: &r, samples: self.samples }
+        )
+    }
+}
+
+impl<'a, T> Index<usize> for Outputs<'a, T> {
+    type Output = [T];
+
+    fn index(&self, i: usize) -> &Self::Output {
+        self.get(i)
+    }
+}
+
+impl<'a, T> IndexMut<usize> for Outputs<'a, T> {
+    fn index_mut(&mut self, i: usize) -> &mut Self::Output {
+        self.get_mut(i)
+    }
+}
+
+/// Iterator over buffers for output channels of an AudioBuffer.
+pub struct OutputIterator<'a, T: 'a> {
+    data: Outputs<'a, T>,
+    i: usize,
+}
+
+impl<'a, T> Iterator for OutputIterator<'a, T> {
+    type Item = &'a mut [T];
+
+    fn next(&mut self) -> Option<Self::Item> {
+        if self.i < self.data.len() {
+            let val = self.data.get_mut(self.i);
+            self.i += 1;
+            Some(val)
+        } else {
+            None
+        }
+    }
+}
+
+impl<'a, T: Sized> IntoIterator for Outputs<'a, T> {
+    type Item = &'a mut [T];
+    type IntoIter = OutputIterator<'a, T>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        OutputIterator { data: self, i: 0 }
+    }
+}
+
+use event::Event;
+use api;
+use std::mem;
+
+/// This buffer is used for sending midi events through the VST interface.
+/// The purpose of this is to convert outgoing midi events from event::Event to api::Events.
+/// It only allocates memory in new() and reuses the memory between calls.
+pub struct SendEventBuffer {
+    buf: Vec<u8>,
+}
+
+impl SendEventBuffer {
+
+    /// Creates a buffer for sending up to the given number of midi events per frame
+    #[inline(always)]
+    pub fn new(len: usize) -> Self {
+        let header_size = mem::size_of::<api::Events>() - (mem::size_of::<*mut api::Event>() * 2);
+        let body_size = mem::size_of::<*mut api::Event>() * len;
+        Self {
+            buf: vec![0u8; header_size + body_size]
         }
     }
 
-    /// Test that creating buffers from raw pointers works.
-    #[test]
-    fn from_raw() {
-        let mut in1: Vec<f32> = (0..SIZE).map(|x| x as f32).collect();
-        let mut in2 = in1.clone();
+    /// Use this for sending midi events to a host or plugin.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use vst2::plugin::{Info, Plugin, HostCallback};
+    /// # use vst2::buffer::{AudioBuffer, SendEventBuffer};
+    /// # use vst2::host::Host;
+    /// # struct ExamplePlugin { host: HostCallback, send_buf: SendEventBuffer }
+    /// # impl Plugin for ExamplePlugin {
+    /// #     fn get_info(&self) -> Info { Default::default() }
+    /// #
+    /// // Processor that clips samples above 0.4 or below -0.4:
+    /// fn process(&mut self, buffer: &mut AudioBuffer<f32>){
+    ///     let events = vec![
+    ///         // ...
+    ///     ];
+    ///     let host = &mut self.host;
+    ///     self.send_buf.send(events, |events| host.process_events(events));
+    /// }
+    /// # }
+    /// ```
+    pub fn send<F: FnOnce(&api::Events)>(&mut self, events: Vec<Event>, callback: F) {
+        use std::cmp::min;
+        use api::flags::REALTIME_EVENT;
 
-        let mut out1 = vec![0.0; SIZE];
-        let mut out2 = out1.clone();
+        let len = min(self.buf.len(), events.len());
 
-        let buffer = unsafe {
-            AudioBuffer::from_raw(vec![in1.as_mut_ptr(), in2.as_mut_ptr()].as_mut_ptr(),
-                                  vec![out1.as_mut_ptr(), out2.as_mut_ptr()].as_mut_ptr(),
-                                  2, 2, SIZE)
+        // The `api::Events` structure uses a variable length array which is difficult to represent in
+        // rust. We begin by creating a vector with the appropriate byte size by calculating the header
+        // and the variable length body seperately.
+
+        let send_events: &mut [*mut api::Event] = unsafe {
+            // The header is updated by casting the array to the `api::Events` type and specifying the
+            // required fields. We create a slice from the position of the first event and the length
+            // of the array.
+            let ptr = self.buf.as_mut_ptr() as *mut api::Events;
+            (*ptr).num_events = len as i32;
+
+            // A slice view of the body
+            slice::from_raw_parts_mut(&mut (*ptr).events[0], len)
         };
 
-        for (input, output) in buffer.zip() {
-            input.into_iter().zip(output.into_iter())
-            .fold(0, |acc, (input, output)| {
-                assert_eq!(*input - acc as f32, 0.0);
-                assert_eq!(*output, 0.0);
-                acc + 1
-            });
+        // Each event is zipped with the target body array slot. Most of what's happening here is just
+        // copying data but the key thing to notice is that each event is boxed and cast to
+        // (*mut api::Event). This way we can let the callback handle the event, and then later create
+        // the box again from the raw pointer so that it can be properly dropped.
+        for (event, out) in events.into_iter().zip(send_events.iter_mut()) {
+            *out = match event {
+                Event::Midi { data, delta_frames, live,
+                              note_length, note_offset,
+                              detune, note_off_velocity } => {
+                    Box::into_raw(Box::new(api::MidiEvent {
+                        event_type: api::EventType::Midi,
+                        byte_size: mem::size_of::<api::MidiEvent>() as i32,
+                        delta_frames: delta_frames,
+                        flags: if live { REALTIME_EVENT.bits() } else { 0 },
+                        note_length: note_length.unwrap_or(0),
+                        note_offset: note_offset.unwrap_or(0),
+                        midi_data: data,
+                        _midi_reserved: 0,
+                        detune: detune,
+                        note_off_velocity: note_off_velocity,
+                        _reserved1: 0,
+                        _reserved2: 0
+                    })) as *mut api::Event
+                }
+                Event::SysEx { payload, delta_frames } => {
+                    Box::into_raw(Box::new(api::SysExEvent {
+                        event_type: api::EventType::SysEx,
+                        byte_size: mem::size_of::<api::SysExEvent>() as i32,
+                        delta_frames: delta_frames,
+                        _flags: 0,
+                        data_size: payload.len() as i32,
+                        _reserved1: 0,
+                        system_data: payload.as_ptr() as *const u8 as *mut u8,
+                        _reserved2: 0,
+                    })) as *mut api::Event
+                }
+                Event::Deprecated(e) => Box::into_raw(Box::new(e))
+            };
+        }
+
+        // Allow the callback to use the pointer
+        callback(unsafe { &*(self.buf.as_ptr() as *const api::Events) });
+
+        // Clean up the created events
+        unsafe {
+            for &mut event in send_events {
+                match (*event).event_type {
+                    api::EventType::Midi => {
+                        drop(Box::from_raw(event as *mut api::MidiEvent));
+                    }
+                    api::EventType::SysEx => {
+                        drop(Box::from_raw(event as *mut api::SysExEvent));
+                    }
+                    _ => {
+                        drop(Box::from_raw(event));
+                    }
+                }
+            }
         }
     }
 }

--- a/src/buffer.rs
+++ b/src/buffer.rs
@@ -224,7 +224,6 @@ use std::mem;
 /// It only allocates memory in new() and reuses the memory between calls.
 pub struct SendEventBuffer {
     buf: Vec<u8>,
-    capacity: usize,
     api_events: Vec<api::SysExEvent>,
 }
 
@@ -256,7 +255,6 @@ impl SendEventBuffer {
         }
         Self {
             buf: buf,
-            capacity: capacity,
             api_events: api_events,
         }
     }
@@ -349,7 +347,7 @@ impl SendEventBuffer {
     fn set_num_events(&mut self, events_len: usize) {
         use std::cmp::min;
         let e = Self::buf_as_api_events(&mut self.buf);
-        e.num_events = min(self.capacity, events_len) as i32;
+        e.num_events = min(self.api_events.len(), events_len) as i32;
     }
 
     /// Use this for sending midi events to a host or plugin.

--- a/src/buffer.rs
+++ b/src/buffer.rs
@@ -14,7 +14,7 @@ pub struct AudioBuffer<'a, T: 'a + Float> {
 
 impl<'a, T: 'a + Float> AudioBuffer<'a, T> {
 
-    /// Create an `AudioBuffer` from slices of raw pointers. Uuseful in a Rust VST host.
+    /// Create an `AudioBuffer` from slices of raw pointers. Useful in a Rust VST host.
     #[inline(always)]
     pub fn new(inputs: &'a [*const T], outputs: &'a mut [*mut T], samples: usize) -> Self {
         Self {
@@ -338,6 +338,64 @@ impl SendEventBuffer {
                     }
                 }
             }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use buffer::AudioBuffer;
+
+    /// Size of buffers used in tests.
+    const SIZE: usize = 1024;
+
+    /// Test that creating and zipping buffers works.
+    ///
+    /// This test creates a channel for 2 inputs and 2 outputs. The input channels are simply values
+    /// from 0 to `SIZE-1` (e.g. [0, 1, 2, 3, 4, .. , SIZE - 1]) and the output channels are just 0.
+    /// This test assures that when the buffers are zipped together, the input values do not change.
+    #[test]
+    fn buffer_zip() {
+        let in1: Vec<f32> = (0..SIZE).map(|x| x as f32).collect();
+        let in2 = in1.clone();
+
+        let mut out1 = vec![0.0; SIZE];
+        let mut out2 = out1.clone();
+
+        let inputs = vec![in1.as_ptr(), in2.as_ptr()];
+        let mut outputs = vec![out1.as_mut_ptr(), out2.as_mut_ptr()];
+        let mut buffer = AudioBuffer::new(&inputs, &mut outputs, SIZE);
+
+        for (input, output) in buffer.zip() {
+            input.into_iter().zip(output.into_iter())
+            .fold(0, |acc, (input, output)| {
+                assert_eq!(*input - acc as f32, 0.0);
+                assert_eq!(*output, 0.0);
+                acc + 1
+            });
+        }
+    }
+
+    /// Test that creating buffers from raw pointers works.
+    #[test]
+    fn from_raw() {
+        let in1: Vec<f32> = (0..SIZE).map(|x| x as f32).collect();
+        let in2 = in1.clone();
+
+        let mut out1 = vec![0.0; SIZE];
+        let mut out2 = out1.clone();
+
+        let inputs = vec![in1.as_ptr(), in2.as_ptr()];
+        let mut outputs = vec![out1.as_mut_ptr(), out2.as_mut_ptr()];
+        let mut buffer = AudioBuffer::from_raw(2, 2, inputs.as_ptr(), outputs.as_mut_ptr(), SIZE);
+
+        for (input, output) in buffer.zip() {
+            input.into_iter().zip(output.into_iter())
+            .fold(0, |acc, (input, output)| {
+                assert_eq!(*input - acc as f32, 0.0);
+                assert_eq!(*output, 0.0);
+                acc + 1
+            });
         }
     }
 }

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -1,0 +1,13 @@
+use plugin::Info;
+
+pub(crate) struct PluginCache {
+    pub info: Info,
+}
+
+impl PluginCache {
+    pub fn new(info: &Info) -> Self {
+        Self {
+            info: info.clone(),
+        }
+    }
+}

--- a/src/event.rs
+++ b/src/event.rs
@@ -13,55 +13,70 @@ pub enum Event<'a> {
     ///
     /// These are sent to the plugin before `Plugin::processing()` or `Plugin::processing_f64()` is
     /// called.
-    Midi {
-        /// The raw midi data associated with this event.
-        data: [u8; 3],
-
-        /// Number of samples into the current processing block that this event occurs on.
-        ///
-        /// E.g. if the block size is 512 and this value is 123, the event will occur on sample
-        /// `samples[123]`.
-        // TODO: Don't repeat this value in all event types
-        delta_frames: i32,
-
-        /// This midi event was created live as opposed to being played back in the sequencer.
-        ///
-        /// This can give the plugin priority over this event if it introduces a lot of latency.
-        live: bool,
-
-        /// The length of the midi note associated with this event, if available.
-        note_length: Option<i32>,
-
-        /// Offset in samples into note from note start, if available.
-        note_offset: Option<i32>,
-
-        /// Detuning between -63 and +64 cents.
-        detune: i8,
-
-        /// Note off velocity between 0 and 127.
-        note_off_velocity: u8,
-    },
+    Midi(MidiEvent),
 
     /// A system exclusive event.
     ///
     /// This is just a block of data and it is up to the plugin to interpret this. Generally used
     /// by midi controllers.
-    SysEx {
-        /// The SysEx payload.
-        payload: &'a [u8],
-
-        /// Number of samples into the current processing block that this event occurs on.
-        ///
-        /// E.g. if the block size is 512 and this value is 123, the event will occur on sample
-        /// `samples[123]`.
-        delta_frames: i32,
-    },
+    SysEx(SysExEvent<'a>),
 
     /// A deprecated event.
     ///
     /// Passes the raw midi event structure along with this so that implementors can handle
     /// optionally handle this event.
     Deprecated(api::Event),
+}
+
+
+/// A midi event.
+///
+/// These are sent to the plugin before `Plugin::processing()` or `Plugin::processing_f64()` is
+/// called.
+#[derive(Copy, Clone)]
+pub struct MidiEvent {
+    /// The raw midi data associated with this event.
+    pub data: [u8; 3],
+
+    /// Number of samples into the current processing block that this event occurs on.
+    ///
+    /// E.g. if the block size is 512 and this value is 123, the event will occur on sample
+    /// `samples[123]`.
+    // TODO: Don't repeat this value in all event types
+    pub delta_frames: i32,
+
+    /// This midi event was created live as opposed to being played back in the sequencer.
+    ///
+    /// This can give the plugin priority over this event if it introduces a lot of latency.
+    pub live: bool,
+
+    /// The length of the midi note associated with this event, if available.
+    pub note_length: Option<i32>,
+
+    /// Offset in samples into note from note start, if available.
+    pub note_offset: Option<i32>,
+
+    /// Detuning between -63 and +64 cents.
+    pub detune: i8,
+
+    /// Note off velocity between 0 and 127.
+    pub note_off_velocity: u8,
+}
+
+/// A system exclusive event.
+///
+/// This is just a block of data and it is up to the plugin to interpret this. Generally used
+/// by midi controllers.
+#[derive(Copy, Clone)]
+pub struct SysExEvent<'a> {
+    /// The SysEx payload.
+    pub payload: &'a [u8],
+
+    /// Number of samples into the current processing block that this event occurs on.
+    ///
+    /// E.g. if the block size is 512 and this value is 123, the event will occur on sample
+    /// `samples[123]`.
+    pub delta_frames: i32,
 }
 
 impl<'a> From<api::Event> for Event<'a> {
@@ -76,7 +91,7 @@ impl<'a> From<api::Event> for Event<'a> {
                 let offset = if event.note_offset > 0 { Some(event.note_offset) } else { None };
                 let flags = flags::MidiEvent::from_bits(event.flags).unwrap();
 
-                Event::Midi {
+                Event::Midi(MidiEvent {
                     data: event.midi_data,
                     delta_frames: event.delta_frames,
                     live: flags.intersects(REALTIME_EVENT),
@@ -84,10 +99,10 @@ impl<'a> From<api::Event> for Event<'a> {
                     note_offset: offset,
                     detune: event.detune,
                     note_off_velocity: event.note_off_velocity
-                }
+                })
             }
 
-            SysEx => Event::SysEx {
+            SysEx => Event::SysEx(SysExEvent {
                 payload: unsafe {
                     // We can safely transmute the event pointer to a `SysExEvent` pointer as
                     // event_type refers to a `SysEx` type.
@@ -96,7 +111,7 @@ impl<'a> From<api::Event> for Event<'a> {
                 },
 
                 delta_frames: event.delta_frames
-            },
+            }),
 
             _ => Event::Deprecated(event),
         }

--- a/src/event.rs
+++ b/src/event.rs
@@ -7,6 +7,7 @@ use api::flags::*;
 use api::{self, flags};
 
 /// A VST event.
+#[derive(Copy, Clone)]
 pub enum Event<'a> {
     /// A midi event.
     ///

--- a/src/interfaces.rs
+++ b/src/interfaces.rs
@@ -11,42 +11,29 @@ use api::consts::*;
 use api::{self, AEffect, ChannelProperties};
 use editor::{Rect, KeyCode, Key, KnobMode};
 use host::Host;
-use event::Event;
 
 /// Deprecated process function.
-pub fn process_deprecated(_effect: *mut AEffect, _inputs_raw: *mut *mut f32, _outputs_raw: *mut *mut f32, _samples: i32) { }
+pub fn process_deprecated(_effect: *mut AEffect, _raw_inputs: *const *const f32, _raw_outputs: *mut *mut f32, _samples: i32) { }
 
 /// VST2.4 replacing function.
-pub fn process_replacing(effect: *mut AEffect, inputs_raw: *mut *mut f32, outputs_raw: *mut *mut f32, samples: i32) {
+pub fn process_replacing(effect: *mut AEffect, raw_inputs: *const *const f32, raw_outputs: *mut *mut f32, samples: i32) {
     // Handle to the vst
     let mut plugin = unsafe { (*effect).get_plugin() };
-
-    let buffer = unsafe {
-        AudioBuffer::from_raw(inputs_raw,
-                              outputs_raw,
-                              plugin.get_info().inputs as usize,
-                              plugin.get_info().outputs as usize,
-                              samples as usize)
-    };
-
-    plugin.process(buffer);
+    let cache = unsafe { (*effect).get_cache() };
+    let info = &mut cache.info;
+    let (input_count, output_count) = (info.inputs as usize, info.outputs as usize);
+    let mut buffer = AudioBuffer::from_raw(input_count, output_count, raw_inputs, raw_outputs, samples as usize);
+    plugin.process(&mut buffer);
 }
 
 /// VST2.4 replacing function with `f64` values.
-pub fn process_replacing_f64(effect: *mut AEffect, inputs_raw: *mut *mut f64, outputs_raw: *mut *mut f64, samples: i32) {
+pub fn process_replacing_f64(effect: *mut AEffect, raw_inputs: *const *const f64, raw_outputs: *mut *mut f64, samples: i32) {
     let mut plugin = unsafe { (*effect).get_plugin() };
-
-    if plugin.get_info().f64_precision {
-        let buffer = unsafe {
-            AudioBuffer::from_raw(inputs_raw,
-                                  outputs_raw,
-                                  plugin.get_info().inputs as usize,
-                                  plugin.get_info().outputs as usize,
-                                  samples as usize)
-        };
-
-        plugin.process_f64(buffer);
-    }
+    let cache = unsafe { (*effect).get_cache() };
+    let info = &mut cache.info;
+    let (input_count, output_count) = (info.inputs as usize, info.outputs as usize);
+    let mut buffer = AudioBuffer::from_raw(input_count, output_count, raw_inputs, raw_outputs, samples as usize);
+    plugin.process_f64(&mut buffer);
 }
 
 /// VST2.4 set parameter function.
@@ -118,12 +105,12 @@ pub fn dispatch(effect: *mut AEffect, opcode: i32, index: i32, value: isize, ptr
                     // Given a Rect** structure
                     // TODO: Investigate whether we are given a valid Rect** pointer already
                     *(ptr as *mut *mut c_void) =
-                        mem::transmute(Box::new(Rect {
+                        Box::into_raw(Box::new(Rect {
                             left: pos.0 as i16, // x coord of position
                             top: pos.1 as i16, // y coord of position
                             right: (pos.0 + size.0) as i16, // x coord of pos + x coord of size
                             bottom: (pos.1 + size.1) as i16 // y coord of pos + y coord of size
-                        }));
+                        })) as *mut _; // TODO: free memory
                 }
             }
         }
@@ -172,16 +159,7 @@ pub fn dispatch(effect: *mut AEffect, opcode: i32, index: i32, value: isize, ptr
         }
 
         OpCode::ProcessEvents => {
-            let events: *const api::Events = ptr as *const api::Events;
-
-            let events: Vec<Event> = unsafe {
-                // Create a slice of type &mut [*mut Event]
-                slice::from_raw_parts(&(*events).events[0], (*events).num_events as usize)
-                // Deref and clone each event to get a slice
-                .iter().map(|item| Event::from(**item)).collect()
-            };
-
-            plugin.process_events(events);
+            plugin.process_events(unsafe { &*(ptr as *const api::Events) });
         }
         OpCode::CanBeAutomated => return plugin.can_be_automated(index) as isize,
         OpCode::StringToParameter => return plugin.string_to_parameter(index, read_string(ptr)) as isize,
@@ -283,16 +261,7 @@ pub fn host_dispatch(host: &mut Host,
         OpCode::GetVendorString => copy_string(ptr, &host.get_info().1, MAX_VENDOR_STR_LEN),
         OpCode::GetProductString => copy_string(ptr, &host.get_info().2, MAX_PRODUCT_STR_LEN),
         OpCode::ProcessEvents => {
-            let events: *const api::Events = ptr as *const api::Events;
-
-            let events: Vec<Event> = unsafe {
-                // Create a slice of type &mut [*mut Event]
-                slice::from_raw_parts(&(*events).events[0], (*events).num_events as usize)
-                // Deref and clone each event to get a slice
-                .iter().map(|item| Event::from(**item)).collect()
-            };
-
-            host.process_events(events);
+            host.process_events(unsafe { &*(ptr as *const api::Events) });
         }
 
         unimplemented => {
@@ -311,95 +280,4 @@ fn read_string(ptr: *mut c_void) -> String {
     String::from_utf8_lossy(
         unsafe { CStr::from_ptr(ptr as *mut c_char).to_bytes() }
     ).into_owned()
-}
-
-/// Translate `Vec<Event>` into `&api::Events` and use via a callback.
-///
-/// Both plugins and hosts can receive VST events, this simply translates the rust structure into
-/// the equivalent API structure and takes care of cleanup.
-pub fn process_events<F>(events: Vec<Event>, callback: F)
-    where F: FnOnce(*mut c_void)
-{
-    use api::flags::REALTIME_EVENT;
-
-    let len = events.len();
-
-    // The `api::Events` structure uses a variable length array which is difficult to represent in
-    // rust. We begin by creating a vector with the appropriate byte size by calculating the header
-    // and the variable length body seperately.
-    let header_size = mem::size_of::<api::Events>() - (mem::size_of::<*mut api::Event>() * 2);
-    let body_size = mem::size_of::<*mut api::Event>() * len;
-
-    let mut send = vec![0u8; header_size + body_size];
-
-    let send_events: &mut [*mut api::Event] = unsafe {
-        // The header is updated by casting the array to the `api::Events` type and specifying the
-        // required fields. We create a slice from the position of the first event and the length
-        // of the array.
-        let ptr = send.as_mut_ptr() as *mut api::Events;
-        (*ptr).num_events = len as i32;
-
-        // A slice view of the body
-        slice::from_raw_parts_mut(&mut (*ptr).events[0], len)
-    };
-
-    // Each event is zipped with the target body array slot. Most of what's happening here is just
-    // copying data but the key thing to notice is that each event is boxed and cast to
-    // (*mut api::Event). This way we can let the callback handle the event, and then later create
-    // the box again from the raw pointer so that it can be properly dropped.
-    for (event, out) in events.iter().zip(send_events.iter_mut()) {
-        *out = match *event {
-            Event::Midi { data, delta_frames, live,
-                          note_length, note_offset,
-                          detune, note_off_velocity } => {
-                Box::into_raw(Box::new(api::MidiEvent {
-                    event_type: api::EventType::Midi,
-                    byte_size: mem::size_of::<api::MidiEvent>() as i32,
-                    delta_frames: delta_frames,
-                    flags: if live { REALTIME_EVENT.bits() } else { 0 },
-                    note_length: note_length.unwrap_or(0),
-                    note_offset: note_offset.unwrap_or(0),
-                    midi_data: data,
-                    _midi_reserved: 0,
-                    detune: detune,
-                    note_off_velocity: note_off_velocity,
-                    _reserved1: 0,
-                    _reserved2: 0
-                })) as *mut api::Event
-            }
-            Event::SysEx { payload, delta_frames } => {
-                Box::into_raw(Box::new(api::SysExEvent {
-                    event_type: api::EventType::SysEx,
-                    byte_size: mem::size_of::<api::SysExEvent>() as i32,
-                    delta_frames: delta_frames,
-                    _flags: 0,
-                    data_size: payload.len() as i32,
-                    _reserved1: 0,
-                    system_data: payload.as_ptr() as *const u8 as *mut u8,
-                    _reserved2: 0,
-                })) as *mut api::Event
-            }
-            Event::Deprecated(e) => Box::into_raw(Box::new(e))
-        };
-    }
-
-    // Allow the callback to use the pointer
-    callback(send.as_mut_ptr() as *mut c_void);
-
-    // Clean up the created events
-    unsafe {
-        for &mut event in send_events {
-            match (*event).event_type {
-                api::EventType::Midi => {
-                    drop(Box::from_raw(event as *mut api::MidiEvent));
-                }
-                api::EventType::SysEx => {
-                    drop(Box::from_raw(event as *mut api::SysExEvent));
-                }
-                _ => {
-                    drop(Box::from_raw(event));
-                }
-            }
-        }
-    }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -90,6 +90,8 @@
 //! [`PluginLoader::load`]: host/struct.PluginLoader.html#method.load
 //!
 
+#![feature(conservative_impl_trait)]
+
 extern crate libc;
 extern crate num_traits;
 extern crate libloading;
@@ -131,10 +133,12 @@ pub mod event;
 pub mod host;
 pub mod plugin;
 mod interfaces;
+mod cache;
 
 use api::{HostCallbackProc, AEffect};
 use api::consts::VST_MAGIC;
 use plugin::{HostCallback, Plugin};
+use cache::PluginCache;
 
 /// Exports the necessary symbols for the plugin to be used by a VST host.
 ///
@@ -170,7 +174,7 @@ pub fn main<T: Plugin + Default>(callback: HostCallbackProc) -> *mut AEffect {
     // Create a Box containing a zeroed AEffect. This is transmuted into a *mut pointer so that it
     // can be passed into the HostCallback `wrap` method. The AEffect is then updated after the vst
     // object is created so that the host still contains a raw pointer to the AEffect struct.
-    let effect = unsafe { mem::transmute(Box::new(mem::zeroed::<AEffect>())) };
+    let effect = unsafe { Box::into_raw(Box::new(mem::zeroed::<AEffect>())) };
 
     let host = HostCallback::wrap(callback, effect);
     if host.vst_version() == 0 { // TODO: Better criteria would probably be useful here...
@@ -233,8 +237,8 @@ pub fn main<T: Plugin + Default>(callback: HostCallbackProc) -> *mut AEffect {
         _offQualities: 0,
         _ioRatio: 0.0,
 
-        object: mem::transmute(Box::new(Box::new(plugin) as Box<Plugin>)),
-        user: ptr::null_mut(),
+        object: Box::into_raw(Box::new(Box::new(plugin) as Box<Plugin>)) as *mut _,
+        user: Box::into_raw(Box::new(PluginCache::new(&info))) as *mut _,
 
         uniqueId: info.unique_id,
         version: info.version,
@@ -316,11 +320,11 @@ mod tests {
 
     #[test]
     fn plugin_drop() {
-        static mut drop_test: bool = false;
+        static mut DROP_TEST: bool = false;
 
         impl Drop for TestPlugin {
             fn drop(&mut self) {
-                unsafe { drop_test = true; }
+                unsafe { DROP_TEST = true; }
             }
         }
 
@@ -330,7 +334,7 @@ mod tests {
         unsafe { (*aeffect).drop_plugin() };
 
         // Assert that the VST is shut down and dropped.
-        assert!(unsafe { drop_test });
+        assert!(unsafe { DROP_TEST });
     }
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -90,7 +90,7 @@
 //! [`PluginLoader::load`]: host/struct.PluginLoader.html#method.load
 //!
 
-#![feature(conservative_impl_trait)]
+#![cfg_attr(feature = "nightly", feature(conservative_impl_trait))]
 
 extern crate libc;
 extern crate num_traits;


### PR DESCRIPTION
… also in process_events(), eliminated Box transmutes where possible etc.

This addresses https://github.com/overdrivenpotato/rust-vst2/issues/28 and other things.
The diff might look confusing (especially for buffer.rs) so I'll explain the changes here:
- Before, `AudioBuffer` allocated in every frame due to the `collect()`s in `from_raw()`. Now, `AudioBuffer` doesn't allocate anymore. I modified the tests to use the new `AudioBuffer`.
When you split an `AudioBuffer` you get zero overhead iterable types `Inputs` and `Outputs` that behave like slices, you can also zip the buffer directly. As you can see in the changes to the examples, both ways work with minimal changes to existing plugins.
- I also removed the allocations in `process_events()` mentioned in that issue, by implementing a function `api::Events::events()` for iterating over midi events when receiving and implementing a `SendEventBuffer` for sending which reuses the memory and only allocates during `new()` for a given maximum of midi events. Only plugins that send midi to the host need to use this (and hosts sending midi to plugins). Unfortunately `impl Trait` is still not in stable, so `api::Events::events()` which returns `impl Iterator` only works on nightly (and the type couldn't be expressed by writing it out because it's a Map with an anonymous closure type). But this function could be in a `nightly` feature (`#[cfg(feature = "nightly")]`), then  we could make `events_raw()` public for people on stable so the user code would use that and do the `.map(..)` part manually, like:
```rust
use event::Event;
use api::Events;
fn process_events(&mut self, events: &Events) {
    for &e in events.events_raw() {
        let event: Event = Event::from(unsafe { *e });
        match event {
            // ...
        }
    }
}
````
But on nightly it's:
```rust
fn process_events(&mut self, events: &Events) {
    for event in events.events() {
        match event {
            // ...
        }
    }
}
```
Btw, I tested this in some example plugins, also in the sine_synth example.
- Changed the examples to use the current crate instead of pulling it from github, by using relative paths. Also changed crate-type to cdylib, [because that's what it should be](https://github.com/rust-lang/rfcs/blob/master/text/1510-cdylib.md). Also makes the resulting dlls smaller and more optimized.
- Changed `midi_note_to_hz()` in the sine_synth example to be more intuitive (and with one less division).
- Changed `ProcessProc` and `ProcessProcF64` to take the input buffer pointers as immutable. I always make the rust pointers for ffi functions immutable if that's the intended usage, even when the C lib didn't do this, because it's an oversight in the C lib and it makes the Rust code stricter/better because in this case AudioBuffer doesn't need to have mutable references to the inputs.
- Changed Box transmutes to `Box::into_raw()` and `from_raw()` in `AEffect::get_plugin()` and `lib::main()` because it's more idiomatic (transmutes should be avoided).
- Added a `PluginCache`. There was a huge inefficiency in `interfaces::process_replacing()` and `process_replacing_f64()` because it called `plugin.get_info()` on **EVERY** frame to get the number of inputs/outputs and whether it supports f64 precision. First of all, that check for f64 precision isn't necessary. I asked more experienced VST plugin devs, they said that the host won't even call this function if the plugin doesn't support f64 precision processing (which they know from calling `get_info()` when loading a plugin and caching that), and even if, that should be a NOP. Secondly and more importantly, `Info` contains multiple `String`s and each of them allocates every time `get_info()` is called. This is very wasteful. Now the `Info` gets called only during plugin initialization and cached in the `PluginCache` which gets stored in the `AEffect::object` user data pointer.
The goal is to have **NO** allocations in the audio thread at all.

Overall the API didn't change much at all:
- `Plugin::process()` now takes a `&mut AudioBuffer<f32>` instead of immutable. Same for the f64 variant.
- `Plugin::process_events()` now takes `&api::Events` instead of `Vec<event::Event>` and uses the zero allocation iterator mentioned above.
- Sending midi events is now done with the `SendEventBuffer`, I added a usage example to the doc.

I made sure the tests succeed and changed the examples in the documentation to match the new API and also tested the audio and midi processing with actual VSTs.